### PR TITLE
Image find all by listing id can make authenticated requests.

### DIFF
--- a/lib/etsy/image.rb
+++ b/lib/etsy/image.rb
@@ -21,8 +21,8 @@ module Etsy
 
     # Fetch all images for a given listing.
     #
-    def self.find_all_by_listing_id(listing_id)
-      get_all("/listings/#{listing_id}/images")
+    def self.find_all_by_listing_id(listing_id, options = {})
+      get_all("/listings/#{listing_id}/images", options)
     end
 
     def self.create(listing, image_path, options = {})

--- a/lib/etsy/listing.rb
+++ b/lib/etsy/listing.rb
@@ -123,7 +123,7 @@ module Etsy
     # The collection of images associated with this listing.
     #
     def images
-      @images ||= Image.find_all_by_listing_id(id)
+      @images ||= Image.find_all_by_listing_id(id, oauth)
     end
 
     # The primary image for this listing.
@@ -209,5 +209,10 @@ module Etsy
       (listing_ids.size > 0) ? Array(find(listing_ids, options)) : []
     end
 
+    private
+    
+    def oauth
+      oauth = (token && secret) ? {:access_token => token, :access_secret => secret} : {}
+    end
   end
 end

--- a/test/unit/etsy/image_test.rb
+++ b/test/unit/etsy/image_test.rb
@@ -5,11 +5,19 @@ module Etsy
 
     context "The Image class" do
 
-      should "be able to find all images for a listing" do
-        images = mock_request('/listings/1/images', {}, 'Image', 'findAllListingImages.json')
-        Image.find_all_by_listing_id(1).should == images
+      context "without oauth" do
+        should "be able to find all images for a listing" do
+          images = mock_request('/listings/1/images', {}, 'Image', 'findAllListingImages.json')
+          Image.find_all_by_listing_id(1, {}).should == images
+        end
       end
 
+      context "with options" do
+        should "be able to find all images for a listing with options in request" do
+          images = mock_request('/listings/1/images', {foo: "bar"}, 'Image', 'findAllListingImages.json')
+          Image.find_all_by_listing_id(1, {foo: "bar"}).should == images
+        end
+      end
     end
 
     context "An instance of the Image class" do

--- a/test/unit/etsy/listing_test.rb
+++ b/test/unit/etsy/listing_test.rb
@@ -196,14 +196,30 @@ module Etsy
         end
       end
 
-      should "have a collection of images" do
-        listing = Listing.new
-        listing.stubs(:id).with().returns(1)
+      context "with oauth" do
+        should "have a collection of images" do
+          listing = Listing.new
+          listing.stubs(:id).with().returns(1)
+          listing.stubs(:token).with().returns("token")
+          listing.stubs(:secret).with().returns("secret")
 
-        Image.stubs(:find_all_by_listing_id).with(1).returns('images')
+          Image.stubs(:find_all_by_listing_id).with(1, {access_token: "token", access_secret: "secret"}).returns('images')
 
-        listing.images.should == 'images'
+          listing.images.should == 'images'
+        end
       end
+
+      context "without oauth" do
+        should "have a collection of images" do
+          listing = Listing.new
+          listing.stubs(:id).with().returns(1)
+
+          Image.stubs(:find_all_by_listing_id).with(1, {}).returns('images')
+
+          listing.images.should == 'images'
+        end
+      end
+
 
       should "have a default image" do
         listing = Listing.new


### PR DESCRIPTION
Kept getting rate limited on my authenticated requests for listings on my public access token. Turns out I was calling listing.images and the call to fetch images wasn't passing the oauth tokens from the listing and thus making public calls. This should fix that.