### PR TITLE
Add options to listing#variations, which requires oauth

### DIFF
--- a/lib/etsy/listing.rb
+++ b/lib/etsy/listing.rb
@@ -133,8 +133,9 @@ module Etsy
       images.first
     end
 
-    def variations
-      self.class.get_all("/listings/#{id}/variations")
+    def variations(options={})
+      options.merge!(:require_secure => true)
+      self.class.get_all("/listings/#{id}/variations", oauth.merge(options))
     end
 
     # If these are your desired variations:


### PR DESCRIPTION
listing#variations current returns [] when called as:

~~~
user = Etsy.myself(token, secret)
shop = user.shop
listing = shop.listings[0]
listing.variations
~~~

Getting variations for a listing require oauth credentials to be passed:

https://www.etsy.com/developers/documentation/reference/variations_property#method_getlistingvariations

This adds an `options` argument to the `variations` method to allow passing in authentication:

~~~
access = {access_token: 'token', access_secret: 'secret'}
listing.variations(access)
~~~

Fixes #107 
