### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - jruby-19mode
   - rbx-2
   - 2.1.5
+
+before_install:
+  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 if RUBY_VERSION < '1.9'
   gem 'activesupport', '< 4.0'
 end
+
+if RUBY_VERSION < '2.0'
+  gem 'json', '<= 1.5.5'
+end


### PR DESCRIPTION
The build was failing due to a combination of incompatible dependencies (the JSON gem wasn't installing on ruby 1.9.3) and a regression in bundler.