### PR TITLE
Extend functionality of receipts and transactions

### DIFF
--- a/lib/etsy/receipt.rb
+++ b/lib/etsy/receipt.rb
@@ -12,12 +12,25 @@ module Etsy
       get_all("/shops/#{shop_id}/receipts", options)
     end
 
+    def self.find_all_by_shop_id_and_status(shop_id, status, options = {})
+      get_all("/shops/#{shop_id}/receipts/#{status}", options)
+    end
+
     def created_at
       Time.at(creation_tsz)
     end
 
     def buyer
       @buyer ||= User.find(buyer_id)
+    end
+
+    def transactions
+      unless @transactions
+        options = {}
+        options = options.merge(:access_token => token, :access_secret => secret) if (token && secret)
+        @transactions = Transaction.find_all_by_receipt_id(id, options)
+      end
+      @transactions
     end
 
   end

--- a/lib/etsy/transaction.rb
+++ b/lib/etsy/transaction.rb
@@ -16,6 +16,11 @@ module Etsy
       get_all("/users/#{user_id}/transactions", options)
     end
 
+    def self.find_all_by_receipt_id(receipt_id, options = {})
+      get_all("/receipts/#{receipt_id}/transactions", options)
+    end
+
+
     def buyer
       @buyer ||= User.find(buyer_id)
     end

--- a/test/unit/etsy/receipt_test.rb
+++ b/test/unit/etsy/receipt_test.rb
@@ -10,6 +10,11 @@ module Etsy
         Receipt.find_all_by_shop_id(1, {'key' => 'value'}).should == receipts
       end
 
+      should "be able to find receipts for a shop that also have a given status" do
+        receipts = mock_request('/shops/1/receipts/open', {'key' => 'value'}, 'Receipt', 'findAllShopReceipts.json')
+        Receipt.find_all_by_shop_id_and_status(1, 'open', {'key' => 'value'}).should == receipts
+      end
+
     end
 
     context "An instance of the Receipt class" do
@@ -86,6 +91,16 @@ module Etsy
         receipt.buyer.should == 'user'
       end
 
+      should "have transaction information" do
+        Transaction.stubs(:find_all_by_receipt_id).with(1, {:access_token=>'token',:access_secret=>'secret'}).returns('transactions')
+
+        receipt = Receipt.new
+        receipt.stubs(:id).with().returns(1)
+        receipt.stubs(:token).with().returns('token')
+        receipt.stubs(:secret).with().returns('secret')
+
+        receipt.transactions.should == 'transactions'
+      end
     end
 
   end

--- a/test/unit/etsy/transaction_test.rb
+++ b/test/unit/etsy/transaction_test.rb
@@ -15,6 +15,10 @@ module Etsy
         Transaction.find_all_by_buyer_id(1, {'key' => 'value'}).should == transactions
       end
 
+      should "be able to find transactions for a receipt" do
+        transactions = mock_request('/receipts/1/transactions', {'key' => 'value'}, 'Transaction', 'findAllShopTransactions.json')
+        Transaction.find_all_by_receipt_id(1, {'key' => 'value'}).should == transactions
+      end
     end
 
     context "An instance of the Transaction class" do


### PR DESCRIPTION
## Summary
* Added the ability to search for receipts by their status (open etc.)
* Taught receipts about transcations - you can now query a receipt for it's transactions
* Added the ability to find all transactions for a receipt ID

## Reasoning
I'm in the process of creating a tool that shows all receipts broken down by status and the items (transactions) that each is composed of. In order to do this I needed to add some additional functionality to the Receipt and Transaction classes.

### Note
Where possible I tried to follow the existing code style used within the project, if there are any changes you'd like me to make let me know and I'll do them ASAP 👍 