### PR TITLE
Switch to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - jruby-19mode
   - rbx-2
   - 2.1.5
+  
+dist: trusty
 
 before_install:
   - gem install bundler


### PR DESCRIPTION
Move to Trusty, as Precise binary archives have been removed from the Rubinius official distribution channel.