### PR TITLE
Changed count to total in model#get_all. 

### DIFF
--- a/etsy.gemspec
+++ b/etsy.gemspec
@@ -26,5 +26,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "jnunemaker-matchy", "~> 0.4.0"
   gem.add_development_dependency 'shoulda', "~> 3.4.0"
   gem.add_development_dependency 'mocha', "~> 0.13.3"
+  # shoulda-context blows up on ActiveSupport not being defined
+  # on shoulda/context.rb:7
+  # But then when you load active_support, shoulda-context decides
+  # to load MiniTest
   gem.add_development_dependency 'test-unit', "~>3.2.5"
 end

--- a/etsy.gemspec
+++ b/etsy.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   # But then when you load active_support, shoulda-context decides
   # to load MiniTest
   gem.add_development_dependency 'minitest', "=4.7.4"
+  gem.add_development_dependency 'test-unit', "~>3.2.5"
 end

--- a/etsy.gemspec
+++ b/etsy.gemspec
@@ -26,10 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "jnunemaker-matchy", "~> 0.4.0"
   gem.add_development_dependency 'shoulda', "~> 3.4.0"
   gem.add_development_dependency 'mocha', "~> 0.13.3"
-  # shoulda-context blows up on ActiveSupport not being defined
-  # on shoulda/context.rb:7
-  # But then when you load active_support, shoulda-context decides
-  # to load MiniTest
-  gem.add_development_dependency 'minitest', "=4.7.4"
   gem.add_development_dependency 'test-unit', "~>3.2.5"
 end

--- a/lib/etsy/model.rb
+++ b/lib/etsy/model.rb
@@ -43,7 +43,7 @@ module Etsy
           if limit == :all
             response = Request.get(endpoint, options.merge(:limit => batch_size, :offset => initial_offset))
             result << response.result
-            limit = [response.count - batch_size - initial_offset, 0].max
+            limit = [response.total - batch_size - initial_offset, 0].max
             initial_offset += batch_size
           end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ $:.reject! { |e| e.include? 'TextMate' }
 
 require 'rubygems'
 require 'active_support' # workaround load issue with shoulda in rubinius
-require 'minitest/autorun' # workaround load issue with shoulda in rubinius
 require 'test/unit'
 require 'shoulda'
 require 'matchy'

--- a/test/unit/etsy/model_test.rb
+++ b/test/unit/etsy/model_test.rb
@@ -30,9 +30,9 @@ module Etsy
       end
 
       should 'perform multiple requests if :limit is greater than 100' do
-        mock_empty_request(:limit => 100, :offset => 0).once
-        mock_empty_request(:limit => 50, :offset => 100).once
-
+        body = '{"count": 150, "pagination":{}}'
+        mock_empty_request(:limit => 100, :offset => 0, :body => body).once
+        mock_empty_request(:limit => 50, :offset => 100, :body => body).once
         TestModel.get_all('', :limit => 150)
       end
 
@@ -52,7 +52,7 @@ module Etsy
       end
 
       should 'perform multiple requests if :limit is :all and count is greater than 100' do
-        body = '{"count": 210}'
+        body = '{"count": 210, "pagination": {}}'
         mock_empty_request(:limit => 100, :offset => 0, :body => body).once
         mock_empty_request(:limit => 100, :offset => 100, :body => body).once
         mock_empty_request(:limit => 10, :offset => 200, :body => body).once


### PR DESCRIPTION
ruby 2.4

Fixed model_tests.rb The stubs now include "pagination":{} where appropriate.   response.rb
line 44. Response#count would return the total number of records, if it was not
paginated, and the batch size if it was paginated. The test mocked the
count, but without pagination would return the total. This caused false
positive test passing.

Fixed model.rb
Line 46. Replaced response.count with response.total. This is the
correct semantics, since count will only be batch size or less.